### PR TITLE
Fix the issue of BioLinkMixin not being extended and used in BioPathwayCard.

### DIFF
--- a/bio-pathway-card.js
+++ b/bio-pathway-card.js
@@ -2,7 +2,7 @@ import { PolymerElement, html } from "@polymer/polymer/polymer-element.js";
 import "@polymer/paper-listbox/paper-listbox";
 import "@polymer/paper-item/paper-item";
 import "@polymer/paper-styles/paper-styles";
-import "@biopolymer-elements/bio-link/bio-link-mixin";
+import { BioLinkMixin } from "@biopolymer-elements/bio-link/bio-link-mixin";
 
 /**
  * `bio-pathway-card`
@@ -12,38 +12,38 @@ import "@biopolymer-elements/bio-link/bio-link-mixin";
  * @demo
  *
  */
-class BioPathwayCard extends PolymerElement {
+class BioPathwayCard extends BioLinkMixin(PolymerElement) {
   static get properties() {
     return {
       /** The name of the pathway database. */
       type: {
         type: String,
-        value: ""
+        value: "",
       },
 
       /** The user-friendly name of the database. */
       name: {
         type: String,
-        computed: "__computeName(type, databases)"
+        computed: "__computeName(type, databases)",
       },
 
       /** A map of database names and user-friendly names. */
       databases: {
         type: Map,
-        value: null
+        value: null,
       },
 
       /** An array of pathway items containing an id and a name. */
       model: {
         type: Array,
-        value: []
+        value: [],
       },
 
       /** A normalised model containing an Array<Object> where each object is the id, and name of the pathway. */
       __model: {
         type: Array,
-        computed: "__computeModel(model)"
-      }
+        computed: "__computeModel(model)",
+      },
     };
   }
 


### PR DESCRIPTION
### Summary of changes

- import `BioLinkMixin` and extend `BioLinkMixin` in `BioPathwayCard` component

### Changes Snippet

#### Before
```
import "@biopolymer-elements/bio-link/bio-link-mixin";

class BioPathwayCard extends PolymerElement {
```

#### After
```
import {BioLinkMixin} from "@biopolymer-elements/bio-link/bio-link-mixin";

class BioPathwayCard extends BioLinkMixin(PolymerElement) {
```