### PR TITLE
Set width of bio-pathway-card to 100%

### DIFF
--- a/bio-pathway-panel.js
+++ b/bio-pathway-panel.js
@@ -69,8 +69,10 @@ class BioPathwaysPanel extends PolymerElement {
           @apply --layout-horizontal;
           @apply --layout-wrap;
         }
+
         bio-pathway-card {
           margin-top: 5px;
+          width: 100%;
         }
       </style>
 


### PR DESCRIPTION
## Summary of Changes
- [X] Set the width of `bio-pathway-card` to 100% so that the card occupies total width of the parent.